### PR TITLE
Add user and role support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,12 @@ func getConfig() (config.Config, error) {
 	if err := viper.UnmarshalKey("server.mapRoles", &config.StaticRoleMappings); err != nil {
 		return config, fmt.Errorf("invalid server role mappings: %v", err)
 	}
+	if err := viper.UnmarshalKey("server.mapEC2InstanceRoles", &config.EC2InstanceRoleMappings); err != nil {
+		logrus.WithError(err).Fatal("invalid server EC2 role mappings")
+	}
+	if err := viper.UnmarshalKey("server.mapUsers", &config.StaticUserMappings); err != nil {
+		logrus.WithError(err).Fatal("invalid server user mappings")
+	}
 
 	if config.ClusterID == "" {
 		return config, errors.New("cluster ID cannot be empty")

--- a/example.yaml
+++ b/example.yaml
@@ -32,13 +32,36 @@ data:
     # (good choices are a random token or a domain name that will be unique to your cluster)
     clusterID: my-dev-cluster.example.com
     server:
-      # a mapping of IAM role (specified by ARN) to a list of Kubernetes group names
+      # each mapRoles entry maps an IAM role to a static username and set of groups
       mapRoles:
-      # map arn:aws:iam::000000000000:role/KubernetesAdmin to a cluster admin (make sure this is )
+      # e.g., map arn:aws:iam::000000000000:role/KubernetesAdmin to a cluster admin
       - roleARN: arn:aws:iam::000000000000:role/KubernetesAdmin
         username: kubernetes-admin
         groups:
          - system:masters
+
+      # mapEC2InstanceRoles is like mapRoles but specifically for EC2 instance
+      # roles. Only use this if you trust that the role can only be assumed by
+      # EC2 (otherwise, you can't trust the EC2 instance ID that comes from the
+      # session name). It has the benefit of letting you include the EC2
+      # instance ID (e.g., "i-0123456789abcdef0") in the generated username.
+      mapEC2InstanceRoles:
+      # e.g., map EC2 instances in my "KubernetesNode" role to users like
+      # "aws:000000000000:instance:i-0123456789abcdef0"
+      - roleARN: arn:aws:iam::000000000000:role/KubernetesNode
+        usernameFormat: aws:{{AccountID}}:instance:{{InstanceID}}
+        groups:
+        - system:bootstrappers
+        - aws:instances
+
+      # each mapUsers entry maps an IAM role to a static username and set of groups
+      mapUsers:
+      # e.g., map user IAM user Alice in 000000000000 to user "alice" in "system:masters"
+      - userARN: arn:aws:iam::000000000000:user/Alice
+        username: alice
+        groups:
+        - system:masters
+
 ---
 apiVersion: extensions/v1beta1
 kind: DaemonSet

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -29,6 +29,37 @@ type StaticRoleMapping struct {
 	Groups []string
 }
 
+// EC2InstanceRoleMapping is a mapping of a single AWS Role ARN that is trusted
+// to be assumed _only_ by EC2 instances. It maps to dynamic set of Kubernetes
+// usernames based on the provided format. It maps to a static list of
+// Kubernetes groups.
+type EC2InstanceRoleMapping struct {
+	// RoleARN is the AWS Resource Name of the role. (e.g., "arn:aws:iam::000000000000:role/Foo").
+	RoleARN string
+
+	// UsernameFormat is the username pattern that this instances assuming this
+	// role will have in Kubernetes. Can contain two template parameters,
+	// "{{AccountID}}" is the 12 digit AWS ID and "{{InstanceID}}" is the EC2
+	// instance ID (e.g., "i-0123456789abcdef0")
+	UsernameFormat string
+
+	// Groups is a list of Kubernetes groups this role will authenticate as (e.g., `system:bootstrappers`)
+	Groups []string
+}
+
+// StaticUserMapping is a static mapping of a single AWS User ARN to a
+// Kubernetes username and a list of Kubernetes groups
+type StaticUserMapping struct {
+	// UserARN is the AWS Resource Name of the user. (e.g., "arn:aws:iam::000000000000:user/Test").
+	UserARN string
+
+	// Username is the Kubernetes username this role will authenticate as (e.g., `mycorp:foo`)
+	Username string
+
+	// Groups is a list of Kubernetes groups this role will authenticate as (e.g., `system:masters`)
+	Groups []string
+}
+
 // Config specifies the configuration for a kubernetes-aws-authenticator server
 type Config struct {
 	// ClusterID is a unique-per-cluster identifier for your
@@ -52,4 +83,13 @@ type Config struct {
 	// StaticRoleMappings is a list of static mappings from AWS IAM Role to
 	// Kubernetes username+group.
 	StaticRoleMappings []StaticRoleMapping
+
+	// EC2InstanceRoleMappings is a list of dynamic mappings from AWS IAM Role
+	// that is assumed only by EC2 instances to Kubernetes username pattern
+	// that includes the instance ID.
+	EC2InstanceRoleMappings []EC2InstanceRoleMapping
+
+	// StaticUserMappings is a list of static mappings from AWS IAM User to
+	// Kubernetes username+group.
+	StaticUserMappings []StaticUserMapping
 }

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -34,6 +34,33 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 )
 
+// Identity is returned on successful Verify() results. It contains a parsed
+// version of the AWS identity used to create the token.
+type Identity struct {
+	// ARN is the raw Amazon Resource Name returned by sts:GetCallerIdentity
+	ARN string
+
+	// CanonicalARN is the Amazon Resource Name converted to a more canonical
+	// representation. In particular, STS assumed role ARNs like
+	// "arn:aws:sts::ACCOUNTID:assumed-role/ROLENAME/SESSIONNAME" are converted
+	// to their IAM ARN equivalent "arn:aws:iam::ACCOUNTID:role/NAME"
+	CanonicalARN string
+
+	// AccountID is the 12 digit AWS account number.
+	AccountID string
+
+	// UserID is the unique user/role ID (e.g., "AROAAAAAAAAAAAAAAAAAA").
+	UserID string
+
+	// SessionName is the STS session name (or "" if this is not a
+	// session-based identity). For EC2 instance roles, this will be the EC2
+	// instance ID (e.g., "i-0123456789abcdef0"). You should only rely on it
+	// if you trust that _only_ EC2 is allowed to assume the IAM Role. If IAM
+	// users or other roles are allowed to assume the role, they can provide
+	// (nearly) arbitrary strings here.
+	SessionName string
+}
+
 const (
 	v1Prefix         = "k8s-aws-v1."
 	maxTokenLenBytes = 1024 * 4
@@ -66,9 +93,17 @@ type getCallerIdentityWrapper struct {
 	} `json:"GetCallerIdentityResponse"`
 }
 
-// Get assumes the given AWS IAM role and returns a kubernetes-aws-authenticator token valid for serverID.
-func Get(roleARN string, serverID string) (string, error) {
-	// Create a session to share configuration, and load external configuration.
+// Get uses the directly available AWS credentials to return a token valid for
+// serverID. It follows the default AWS credential handling behavior.
+func Get(serverID string) (string, error) {
+	return GetWithRole(serverID, "")
+}
+
+// GetWithRole assumes the given AWS IAM role and returns a token valid for
+// serverID. If roleARN is empty, behaves like Get (does not assume a role).
+func GetWithRole(serverID string, roleARN string) (string, error) {
+	// create a session with the "base" credentials available
+	// (from environment variable, profile files, EC2 metadata, etc)
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	})
@@ -76,17 +111,24 @@ func Get(roleARN string, serverID string) (string, error) {
 		return "", fmt.Errorf("could not create session: %v", err)
 	}
 
-	// create STS-based credentials that will assume the given role
-	creds := stscreds.NewCredentials(sess, roleARN)
+	// use an STS client based on the direct credentials
+	stsAPI := sts.New(sess)
 
-	// create
-	stsAPI := sts.New(sess, &aws.Config{Credentials: creds})
+	// if a roleARN was specified, replace the STS client with one that uses
+	// temporary credentials from that role.
+	if roleARN != "" {
+		// create STS-based credentials that will assume the given role
+		creds := stscreds.NewCredentials(sess, roleARN)
 
+		// create an STS API interface that uses the assumed role's temporary credentials
+		stsAPI = sts.New(sess, &aws.Config{Credentials: creds})
+	}
+
+	// generate an sts:GetCallerIdentity request and add our custom server ID header
 	request, _ := stsAPI.GetCallerIdentityRequest(&sts.GetCallerIdentityInput{})
-
-	// set our fixed header as a hardening measure (to prevent some confused deputy vulns)
 	request.HTTPRequest.Header.Add(serverIDHeader, serverID)
 
+	// sign the request
 	presignedURLString, err := request.Presign(60 * time.Second)
 	if err != nil {
 		return "", err
@@ -96,62 +138,64 @@ func Get(roleARN string, serverID string) (string, error) {
 	return v1Prefix + base64.RawURLEncoding.EncodeToString([]byte(presignedURLString)), nil
 }
 
-// Verify an kubernetes-aws-authenticator token is valid for the specified serverID
-func Verify(token string, serverID string) (string, error) {
+// Verify a token is valid for the specified serverID. On success, returns an
+// Identity that contains information about the AWS principal that created the
+// token. On failure, returns nil and a non-nil error.
+func Verify(token string, serverID string) (*Identity, error) {
 	if len(token) > maxTokenLenBytes {
-		return "", fmt.Errorf("token is too large")
+		return nil, fmt.Errorf("token is too large")
 	}
 
 	if !strings.HasPrefix(token, v1Prefix) {
-		return "", fmt.Errorf("token is missing expected %q prefix", v1Prefix)
+		return nil, fmt.Errorf("token is missing expected %q prefix", v1Prefix)
 	}
 
 	// TODO: this may need to be a constant-time base64 decoding
 	tokenBytes, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(token, v1Prefix))
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	parsedURL, err := url.Parse(string(tokenBytes))
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if parsedURL.Scheme != "https" {
-		return "", fmt.Errorf("unexpected scheme %q in pre-signed URL", parsedURL.Scheme)
+		return nil, fmt.Errorf("unexpected scheme %q in pre-signed URL", parsedURL.Scheme)
 	}
 
 	if parsedURL.Host != "sts.amazonaws.com" {
-		return "", fmt.Errorf("unexpected hostname in pre-signed URL")
+		return nil, fmt.Errorf("unexpected hostname in pre-signed URL")
 	}
 
 	if parsedURL.Path != "/" {
-		return "", fmt.Errorf("unexpected path in pre-signed URL")
+		return nil, fmt.Errorf("unexpected path in pre-signed URL")
 	}
 
 	queryParamsLower := make(url.Values)
 	queryParams := parsedURL.Query()
 	for key, values := range queryParams {
 		if !parameterWhitelist[strings.ToLower(key)] {
-			return "", fmt.Errorf("non-whitelisted query parameter %q", key)
+			return nil, fmt.Errorf("non-whitelisted query parameter %q", key)
 		}
 		if len(values) != 1 {
-			return "", fmt.Errorf("query parameter with multiple values not supported")
+			return nil, fmt.Errorf("query parameter with multiple values not supported")
 		}
 		queryParamsLower.Set(strings.ToLower(key), values[0])
 	}
 
 	if queryParamsLower.Get("action") != "GetCallerIdentity" {
-		return "", fmt.Errorf("unexpected action parameter in pre-signed URL")
+		return nil, fmt.Errorf("unexpected action parameter in pre-signed URL")
 	}
 
 	if !hasSignedServerIDHeader(&queryParamsLower) {
-		return "", fmt.Errorf("client did not sign the %s header in the pre-signed URL", serverIDHeader)
+		return nil, fmt.Errorf("client did not sign the %s header in the pre-signed URL", serverIDHeader)
 	}
 
 	expires, err := strconv.Atoi(queryParamsLower.Get("x-amz-expires"))
 	if err != nil || expires < 0 || expires > 60 {
-		return "", fmt.Errorf("invalid X-Amz-Expires parameter in pre-signed URL")
+		return nil, fmt.Errorf("invalid X-Amz-Expires parameter in pre-signed URL")
 	}
 
 	req, err := http.NewRequest("GET", parsedURL.String(), nil)
@@ -162,28 +206,52 @@ func Verify(token string, serverID string) (string, error) {
 	if err != nil {
 		// special case to avoid printing the full URL if possible
 		if urlErr, ok := err.(*url.Error); ok {
-			return "", fmt.Errorf("error during GET: %v", urlErr.Err)
+			return nil, fmt.Errorf("error during GET: %v", urlErr.Err)
 		}
-		return "", fmt.Errorf("error during GET: %v", err)
+		return nil, fmt.Errorf("error during GET: %v", err)
 	}
 	defer response.Body.Close()
 
 	if response.StatusCode != 200 {
-		return "", fmt.Errorf("error from AWS (expected 200, got %d)", response.StatusCode)
+		return nil, fmt.Errorf("error from AWS (expected 200, got %d)", response.StatusCode)
 	}
 
 	responseBody, err := ioutil.ReadAll(response.Body)
 	if err != nil {
-		return "", fmt.Errorf("error reading HTTP result: %v", err)
+		return nil, fmt.Errorf("error reading HTTP result: %v", err)
 	}
 
 	var callerIdentity getCallerIdentityWrapper
 	err = json.Unmarshal(responseBody, &callerIdentity)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return canonicalizeARN(callerIdentity.GetCallerIdentityResponse.GetCallerIdentityResult.Arn)
+	// parse the response into an Identity
+	id := &Identity{
+		ARN:       callerIdentity.GetCallerIdentityResponse.GetCallerIdentityResult.Arn,
+		AccountID: callerIdentity.GetCallerIdentityResponse.GetCallerIdentityResult.Account,
+	}
+	id.CanonicalARN, err = canonicalizeARN(id.ARN)
+	if err != nil {
+		return nil, err
+	}
+
+	// The user ID is either UserID:SessionName (for assumed roles) or just
+	// UserID (for IAM User principals).
+	userIDParts := strings.Split(callerIdentity.GetCallerIdentityResponse.GetCallerIdentityResult.UserID, ":")
+	if len(userIDParts) == 2 {
+		id.UserID = userIDParts[0]
+		id.SessionName = userIDParts[1]
+	} else if len(userIDParts) == 1 {
+		id.UserID = userIDParts[0]
+	} else {
+		return nil, fmt.Errorf(
+			"malformed UserID %q",
+			callerIdentity.GetCallerIdentityResponse.GetCallerIdentityResult.UserID)
+	}
+
+	return id, nil
 }
 
 func hasSignedServerIDHeader(paramsLower *url.Values) bool {
@@ -200,11 +268,23 @@ var assumedRoleARNPattern = regexp.MustCompile(
 	`\Aarn:aws:sts::([\d]{12}):assumed-role/([\w+=,.@-]+)/([\w+=,.@-]*)\z`,
 )
 
+var userARNPattern = regexp.MustCompile(
+	`\Aarn:aws:iam::([\d]{12}):user/([\w+=,.@-]+)\z`,
+)
+
 func canonicalizeARN(arn string) (string, error) {
-	parts := assumedRoleARNPattern.FindStringSubmatch(arn)
-	if len(parts) != 4 {
-		return "", fmt.Errorf("malformed ARN %q", arn)
+	// we'll say that user ARNs are already canonical
+	if userARNPattern.MatchString(arn) {
+		return arn, nil
 	}
-	accountID, roleName := parts[1], parts[2]
-	return fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, roleName), nil
+
+	// convert assumed-role ARNs to the more common arn:aws:iam::ACCOUNT:role/NAME format
+	parts := assumedRoleARNPattern.FindStringSubmatch(arn)
+	if parts != nil && len(parts) == 4 {
+		accountID, roleName := parts[1], parts[2]
+		return fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, roleName), nil
+	}
+
+	// otherwise we don't understand this ARN format so return an error
+	return "", fmt.Errorf("malformed ARN %q", arn)
 }

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -35,9 +35,9 @@ import (
 )
 
 const (
-	v1Prefix         = "kubernetes-aws-authenticator-v1."
+	v1Prefix         = "k8s-aws-v1."
 	maxTokenLenBytes = 1024 * 4
-	serverIDHeader   = "x-kubernetes-aws-authenticator-server-id"
+	serverIDHeader   = "x-k8s-aws-id"
 )
 
 var parameterWhitelist = map[string]bool{


### PR DESCRIPTION
The main change here is adding support for two new kinds of mappings between AWS ARNs and Kubernetes identities:
 - A `mapUsers` config type that statically maps an IAM user to a Kubernetes user+groups.
 - A `mapEC2InstanceRoles` config type that maps an EC2 instance role to a dynamic username pattern that includes the instance ID. This has some caveats but I'm hoping it is useful for cluster bootstrapping.

I also added support for generating tokens from IAM user or EC2 instance role credentials by making the `--role` flag in `kubernetes-aws-authenticator token` optional. Now, it defaults to signing the `sts:GetCallerIdentity` request with your "base" AWS credentials (from the environment, profile file, EC2 metadata, etc.).

Fixes https://github.com/heptiolabs/kubernetes-aws-authenticator/issues/4 (EC2 instance role support)
Fixes https://github.com/heptiolabs/kubernetes-aws-authenticator/issues/6 (IAM user support)