### PR TITLE
Support pre-generating assets by running the init sub-command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,7 @@ ca-certificates.crt:
 
 push:
 	docker push $(REPO):$(VERSION)
+
+format:
+	test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -d {} + | tee /dev/stderr)" || \
+	test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -w {} + | tee /dev/stderr)"

--- a/README.md
+++ b/README.md
@@ -52,6 +52,25 @@ The server is meant to run on each of your master nodes as a DaemonSet with host
 
 For a sample ConfigMap and DaemonSet configuration, see [`example.yaml`](./example.yaml).
 
+Also note that you must generate and copy all the files required by the server to master nodes, or otherwise any pod in the daemonset will fail to start.
+
+Fortunately, kubernetes-aws-authenticator has a convenient command to generate the files for you.
+Run the `init` command:
+
+```
+$ ./kubernetes-aws-authenticator -c config.yaml init
+INFO[2017-10-17T16:39:42+09:00] generated a new private key and certificate   certBytes=819 keyBytes=1192
+INFO[2017-10-17T16:39:42+09:00] saving new key and certificate                certPath=cert.pem keyPath=key.pem
+INFO[2017-10-17T16:39:42+09:00] loaded existing keypair                       certPath=cert.pem keyPath=key.pem
+INFO[2017-10-17T16:39:42+09:00] writing webhook kubeconfig file               kubeconfigPath=kubernetes-aws-authenticator.kubeconfig
+INFO[2017-10-17T16:39:42+09:00] copy cert.pem to /var/kubernetes-aws-authenticator/cert.pem on kubernetes master node(s)
+INFO[2017-10-17T16:39:42+09:00] copy key.pem to /var/kubernetes-aws-authenticator/key.pem on kubernetes master node(s)
+INFO[2017-10-17T16:39:42+09:00] copy kubernetes-aws-authenticator.kubeconfig to /etc/kubernetes/kubernetes-aws-authenticator.kubeconfig on kubernetes master node(s)
+INFO[2017-10-17T16:39:42+09:00] configure your apiserver with `--authentication-token-webhook-config-file=/etc/kubernetes/kubernetes-aws-authenticator.kubeconfig` to enable authentication with kubernetes-aws-authenticator
+```
+
+Then, you should upload mentioned files accordingly by utilizing your node/cluster provisioning tool or manually.
+
 ### 3. Configure your API server to talk to the server
 The Kubernetes API integrates with kubernetes-aws-authenticator using a [token authentication webhook](https://kubernetes.io/docs/admin/authentication/#webhook-token-authentication).
 When you run `kubernetes-aws-authenticator server`, it will generate a webhook configuration file and save it onto the host filesystem.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2017 by the contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize kubernetes-aws-authenticator by generating the key used by the server, a kubeconfig used by clients, the certificate used between both",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg, err := getConfig()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "could not get config: %v\n", err)
+			os.Exit(1)
+		}
+
+		localCfg := cfg
+		localCfg.GenerateKubeconfigPath = "./kubernetes-aws-authenticator.kubeconfig"
+		localCfg.StateDir = "./"
+
+		err = localCfg.GenerateFiles()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "could not initialize: %v\n", err)
+			os.Exit(1)
+		}
+
+		logrus.Infof("please put ./cert.pem to %s/cert.pem on kubernetes master node(s)", cfg.StateDir)
+		logrus.Infof("please put ./key.pem to %s/key.pem on kubernetes master node(s)", cfg.StateDir)
+		logrus.Info("please put kubernetes-aws-authenticator.kubeconfig to /etc/kubernetes/kubernetes-aws-authenticator.kubeconfig on kubernetes master node(s)")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(initCmd)
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -26,7 +26,7 @@ import (
 
 var initCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Initialize kubernetes-aws-authenticator by generating the key used by the server, a kubeconfig used by clients, the certificate used between both",
+	Short: "Pre-generate certificate, private key, and kubeconfig files for the server.",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg, err := getConfig()
@@ -36,7 +36,7 @@ var initCmd = &cobra.Command{
 		}
 
 		localCfg := cfg
-		localCfg.GenerateKubeconfigPath = "./kubernetes-aws-authenticator.kubeconfig"
+		localCfg.GenerateKubeconfigPath = "kubernetes-aws-authenticator.kubeconfig"
 		localCfg.StateDir = "./"
 
 		err = localCfg.GenerateFiles()
@@ -45,9 +45,10 @@ var initCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		logrus.Infof("please put ./cert.pem to %s/cert.pem on kubernetes master node(s)", cfg.StateDir)
-		logrus.Infof("please put ./key.pem to %s/key.pem on kubernetes master node(s)", cfg.StateDir)
-		logrus.Info("please put kubernetes-aws-authenticator.kubeconfig to /etc/kubernetes/kubernetes-aws-authenticator.kubeconfig on kubernetes master node(s)")
+		logrus.Infof("copy %s to %s on kubernetes master node(s)", localCfg.CertPath(), cfg.CertPath())
+		logrus.Infof("copy %s to %s on kubernetes master node(s)", localCfg.KeyPath(), cfg.KeyPath())
+		logrus.Infof("copy %s to %s on kubernetes master node(s)", localCfg.GenerateKubeconfigPath, cfg.GenerateKubeconfigPath)
+		logrus.Infof("configure your apiserver with `--authentication-token-webhook-config-file=%s` to enable authentication with kubernetes-aws-authenticator", cfg.GenerateKubeconfigPath)
 	},
 }
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -33,20 +33,13 @@ var serverCmd = &cobra.Command{
 	Short: "Run a webhook validation server suitable that validates tokens using AWS IAM",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		config := server.Config{
-			ClusterID:              viper.GetString("clusterID"),
-			LocalhostPort:          viper.GetInt("server.port"),
-			GenerateKubeconfigPath: viper.GetString("server.generateKubeconfig"),
-			StateDir:               viper.GetString("server.stateDir"),
-		}
-		if err := viper.UnmarshalKey("server.mapRoles", &config.StaticRoleMappings); err != nil {
-			logrus.WithError(err).Fatal("invalid server role mappings")
+		config, err := getConfig()
+
+		if err != nil {
+			logrus.Fatalf("%s", err)
 		}
 
-		if config.ClusterID == "" {
-			logrus.Fatal("cluster ID cannot be empty")
-		}
-		config.Run()
+		server.New(config).Run()
 	},
 }
 

--- a/pkg/config/certs.go
+++ b/pkg/config/certs.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package server
+package config
 
 import (
 	"crypto/rand"
@@ -41,9 +41,9 @@ func (c *Config) keyPath() string {
 	return filepath.Join(c.StateDir, keyFilename)
 }
 
-func (c *Config) getCertificate() (*tls.Certificate, error) {
+func (c *Config) CreateCertificate() (*tls.Certificate, error) {
 	// first try to load the existing keypair
-	cert, err := c.loadExistingCertificate()
+	cert, err := c.LoadExistingCertificate()
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func (c *Config) getCertificate() (*tls.Certificate, error) {
 	return &newCert, err
 }
 
-func (c *Config) loadExistingCertificate() (*tls.Certificate, error) {
+func (c *Config) LoadExistingCertificate() (*tls.Certificate, error) {
 
 	// if either file does not exist, we'll consider that not an error but
 	// return a nil

--- a/pkg/config/certs.go
+++ b/pkg/config/certs.go
@@ -41,7 +41,7 @@ func (c *Config) keyPath() string {
 	return filepath.Join(c.StateDir, keyFilename)
 }
 
-func (c *Config) CreateCertificate() (*tls.Certificate, error) {
+func (c *Config) GetOrCreateCertificate() (*tls.Certificate, error) {
 	// first try to load the existing keypair
 	cert, err := c.LoadExistingCertificate()
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ func (c *Config) ListenAddr() string {
 
 func (c *Config) GenerateFiles() error {
 	// load or generate a certificate+private key
-	_, err := c.CreateCertificate()
+	_, err := c.GetOrCreateCertificate()
 	if err != nil {
 		return fmt.Errorf("could not load/generate a certificate")
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2017 by the contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+func (c *Config) ListenURL() string {
+	return fmt.Sprintf("https://%s/authenticate", c.ListenAddr())
+}
+
+func (c *Config) ListenAddr() string {
+	// we always listen on localhost (and run with host networking)
+	return fmt.Sprintf("127.0.0.1:%d", c.LocalhostPort)
+}
+
+func (c *Config) GenerateFiles() error {
+	// load or generate a certificate+private key
+	_, err := c.CreateCertificate()
+	if err != nil {
+		return fmt.Errorf("could not load/generate a certificate")
+	}
+	err = c.CreateKubeconfig()
+	if err != nil {
+		return fmt.Errorf("could not generate a webhook kubeconfig")
+	}
+	return nil
+}
+
+func (c *Config) CreateKubeconfig() error {
+	cert, err := c.LoadExistingCertificate()
+	if err != nil {
+		return fmt.Errorf("failed to load an existing certificate: %v", err)
+	}
+
+	// write a kubeconfig suitable for the API server to call us
+	logrus.WithField("kubeconfigPath", c.GenerateKubeconfigPath).Info("writing webhook kubeconfig file")
+	err = kubeconfigParams{
+		ServerURL:                  c.ListenURL(),
+		CertificateAuthorityBase64: certToPEMBase64(cert.Certificate[0]),
+	}.writeTo(c.GenerateKubeconfigPath)
+	if err != nil {
+		logrus.WithField("kubeconfigPath", c.GenerateKubeconfigPath).WithError(err).Fatal("could not write kubeconfig")
+	}
+	return nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/sirupsen/logrus"
 )
@@ -60,4 +61,14 @@ func (c *Config) CreateKubeconfig() error {
 		logrus.WithField("kubeconfigPath", c.GenerateKubeconfigPath).WithError(err).Fatal("could not write kubeconfig")
 	}
 	return nil
+}
+
+// CertPath returns the path to the pem file containing the certificate
+func (c *Config) CertPath() string {
+	return filepath.Join(c.StateDir, "cert.pem")
+}
+
+// KeyPath returns the path to the pem file containing the private key
+func (c *Config) KeyPath() string {
+	return filepath.Join(c.StateDir, "key.pem")
 }

--- a/pkg/config/constants.go
+++ b/pkg/config/constants.go
@@ -14,18 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package server
+package config
 
-import (
-	"github.com/heptiolabs/kubernetes-aws-authenticator/pkg/config"
+import "time"
+
+const (
+	// certFilename is the filename (under the StateDir) where the self-signed
+	// CA certificate will be stored.
+	certFilename = "cert.pem"
+
+	// keyFilename is the filename (under the StateDir) where the private key
+	// will be stored.
+	keyFilename = "key.pem"
+
+	// certLifetime is the lifetime of the CA certificate (100 years)
+	certLifetime = time.Hour * 24 * 365 * 100
 )
-
-// StaticRoleMapping is a static mapping of a single AWS Role ARN to a
-// Kubernetes username and a list of Kubernetes groups
-type Server struct {
-	// Config is the whole configuration of kubernetes-aws-authenticator used for valid keys and certs, kubeconfig, and so on
-	config.Config
-
-	// InitOnServer is set to true when you'd like to generate the key, the certificate, and kubeconfig on server-side
-	InitOnServer bool
-}

--- a/pkg/config/kubeconfig.go
+++ b/pkg/config/kubeconfig.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package server
+package config
 
 import (
 	"os"

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2017 by the contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+// StaticRoleMapping is a static mapping of a single AWS Role ARN to a
+// Kubernetes username and a list of Kubernetes groups
+type StaticRoleMapping struct {
+	// RoleARN is the AWS Resource Name of the role. (e.g., "arn:aws:iam::000000000000:role/Foo").
+	RoleARN string
+
+	// Username is the Kubernetes username this role will authenticate as (e.g., `mycorp:foo`)
+	Username string
+
+	// Groups is a list of Kubernetes groups this role will authenticate as (e.g., `system:masters`)
+	Groups []string
+}
+
+// Config specifies the configuration for a kubernetes-aws-authenticator server
+type Config struct {
+	// ClusterID is a unique-per-cluster identifier for your
+	// kubernetes-aws-authenticator installation.
+	ClusterID string
+
+	// LocalhostPort is the TCP on which to listen for authentication checks
+	// (on localhost).
+	LocalhostPort int
+
+	// GenerateKubeconfigPath is the output path where a generated webhook
+	// kubeconfig (for `--authentication-token-webhook-config-file`) will be
+	// stored.
+	GenerateKubeconfigPath string
+
+	// StateDir is the directory where generated certificates and private keys
+	// will be stored. You want these persisted between runs so that your API
+	// server webhook configuration doesn't change on restart.
+	StateDir string
+
+	// StaticRoleMappings is a list of static mappings from AWS IAM Role to
+	// Kubernetes username+group.
+	StaticRoleMappings []StaticRoleMapping
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -60,27 +60,6 @@ func New(config config.Config) *Server {
 	}
 }
 
-func (s *Server) LoadOrCreateCertificate() (*tls.Certificate, error) {
-	if s.InitOnServer {
-		cert, err := s.GetOrCreateCertificate()
-		return cert, err
-	} else {
-		cert, err := s.LoadExistingCertificate()
-		return cert, err
-	}
-
-}
-
-func (s *Server) CreateKubeconfigIfNecessary() error {
-	if s.InitOnServer {
-		err := s.CreateKubeconfig()
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // Run the authentication webhook server.
 func (c *Server) Run() {
 	for _, mapping := range c.StaticRoleMappings {
@@ -95,15 +74,9 @@ func (c *Server) Run() {
 	listenAddr := fmt.Sprintf("127.0.0.1:%d", c.LocalhostPort)
 	listenURL := fmt.Sprintf("https://%s/authenticate", listenAddr)
 
-	// load or generate a certificate+private key
-	cert, err := c.LoadOrCreateCertificate()
+	cert, err := c.LoadExistingCertificate()
 	if err != nil {
 		logrus.WithError(err).Fatalf("could not load/generate a certificate")
-	}
-
-	err = c.CreateKubeconfigIfNecessary()
-	if err != nil {
-		logrus.WithError(err).Fatalf("could not create a kubeconfig")
 	}
 
 	// start a TLS listener with our custom certs

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -62,7 +62,7 @@ func New(config config.Config) *Server {
 
 func (s *Server) LoadOrCreateCertificate() (*tls.Certificate, error) {
 	if s.InitOnServer {
-		cert, err := s.CreateCertificate()
+		cert, err := s.GetOrCreateCertificate()
 		return cert, err
 	} else {
 		cert, err := s.LoadExistingCertificate()

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -25,7 +25,4 @@ import (
 type Server struct {
 	// Config is the whole configuration of kubernetes-aws-authenticator used for valid keys and certs, kubeconfig, and so on
 	config.Config
-
-	// InitOnServer is set to true when you'd like to generate the key, the certificate, and kubeconfig on server-side
-	InitOnServer bool
 }


### PR DESCRIPTION
This adds `init` sub-command to be used to pre-generate all the assets required by the kubernetes-aws-authenticator server.
Generated assets should be installed on master nodes of your kubernetes cluster.

The server has been modified not to generate a key, a certificate and a kubeconfig by default accordingly.

Resolves #5

## Usage

Before provisioning your cluster with a cluster provisioning tool like kops, kube-aws, etc., run:

```
kubernetes-aws-authenticator -c config.yaml init
```

so that it generates the following assets:

* ./key.pem
* ./cert.pem
* ./kubernetes-aws-authenticator.kubeconfig

In the default configuration, those files should respectively put to:

* /var/kubernetes-aws-authenticator/key.pem
* /var/kubernetes-aws-authenticator/cert.pem
* The path passed to the apiserver via `--authentication-token-webhook-config-file`

Finally, deploy kubernetes-aws-authenticator to your kubernetes cluster as usual.

## Testing

This change is verified to work on a kube-aws cluster with a kubernetes-aws-authenticator deployment.

```
$ kubernetes-aws-authenticator init -c webhook.yaml
INFO[2017-10-14T19:56:16+09:00] generated a new private key and certificate   certBytes=818 keyBytes=1190
INFO[2017-10-14T19:56:16+09:00] saving new key and certificate                certPath=cert.pem keyPath=key.pem
INFO[2017-10-14T19:56:16+09:00] please put ./cert.pem to /var/kubernetes-aws-authenticator/cert.pem on kubernetes master node(s)
INFO[2017-10-14T19:56:16+09:00] please put ./key.pem to /var/kubernetes-aws-authenticator/key.pem on kubernetes master node(s)
INFO[2017-10-14T19:56:16+09:00] please put kubernetes-aws-authenticator.kubeconfig to /etc/kubernetes/kubernetes-aws-authenticator.kubeconfig on kubernetes master node(s)

$ kubectl --token $(kubernetes-aws-authenticator token -c webhook.yaml) --user kubernetes-admin get no
NAME                                            STATUS    AGE       VERSION
ip-10-0-0-114.ap-northeast-1.compute.internal   Ready     40m       v1.7.6+coreos.0
ip-10-0-0-184.ap-northeast-1.compute.internal   Ready     1h        v1.7.6+coreos.0

$ cat kubeconfig
apiVersion: v1
kind: Config
clusters:
- cluster:
    certificate-authority: credentials/ca.pem
    server: https://<myhostname>
  name: kube-aws-k8s1-cluster
contexts:
- context:
    cluster: kube-aws-k8s1-cluster
    namespace: default
    user: kube-aws-k8s1-admin
  name: kube-aws-k8s1-context
users:
- name: kube-aws-k8s1-admin
  user:
    client-certificate: credentials/admin.pem
    client-key: credentials/admin-key.pem
- name: kubernetes-admin
current-context: kube-aws-k8s1-context

$ kubectl --token $(kubernetes-aws-authenticator token -c webhook.yaml) --user kubernetes-admin get no
NAME                                            STATUS    AGE       VERSION
ip-10-0-0-114.ap-northeast-1.compute.internal   Ready     40m       v1.7.6+coreos.0
ip-10-0-0-184.ap-northeast-1.compute.internal   Ready     1h        v1.7.6+coreos.0
```
